### PR TITLE
Resolves bug due to name issues of the data roles on Chart

### DIFF
--- a/Quickly create and personalize visuals/js/globals.js
+++ b/Quickly create and personalize visuals/js/globals.js
@@ -8,12 +8,6 @@ const visualCreatorShowcaseState = {
     page: null, // The page from where the 3x3 visuals will be displayed
     newVisual: null, // New visual to be created on the page for the base-report
     visualType: null,
-    // dataRoles: {
-    //     Legend: null,
-    //     Values: null,
-    //     Axis: null,
-    //     Tooltips: null,
-    // },
     dataRoleNames: {
         Series: null,
         Category: null,

--- a/Quickly create and personalize visuals/js/globals.js
+++ b/Quickly create and personalize visuals/js/globals.js
@@ -8,10 +8,16 @@ const visualCreatorShowcaseState = {
     page: null, // The page from where the 3x3 visuals will be displayed
     newVisual: null, // New visual to be created on the page for the base-report
     visualType: null,
-    dataRoles: {
-        Legend: null,
-        Values: null,
-        Axis: null,
+    // dataRoles: {
+    //     Legend: null,
+    //     Values: null,
+    //     Axis: null,
+    //     Tooltips: null,
+    // },
+    dataRoleNames: {
+        Series: null,
+        Category: null,
+        Y: null,
         Tooltips: null,
     },
     dataFieldsCount: 0,

--- a/Quickly create and personalize visuals/js/visuals.js
+++ b/Quickly create and personalize visuals/js/visuals.js
@@ -5,19 +5,19 @@
 
 // Define the available data roles for the visual types
 const visualTypeToDataRoles = [
-    { name: "columnChart", displayName: "Column chart", dataRoles: ["Axis", "Values", "Tooltips"], dataRoleNames: ["Category", "Y", "Tooltips"] },
-    { name: "areaChart", displayName: "Area chart", dataRoles: ["Axis", "Legend", "Values"], dataRoleNames: ["Category", "Series", "Y"] },
-    { name: "barChart", displayName: "Bar chart", dataRoles: ["Axis", "Values", "Tooltips"], dataRoleNames: ["Category", "Y", "Tooltips"] },
-    { name: "pieChart", displayName: "Pie chart", dataRoles: ["Legend", "Values", "Tooltips"], dataRoleNames: ["Category", "Y", "Tooltips"] },
-    { name: "lineChart", displayName: "Line chart", dataRoles: ["Axis", "Legend", "Values"], dataRoleNames: ["Category", "Series", "Y"] },
+    { name: "columnChart", displayName: "Column chart", dataRoleNames: ["Category", "Y", "Tooltips"] },
+    { name: "areaChart", displayName: "Area chart", dataRoleNames: ["Category", "Series", "Y"] },
+    { name: "barChart", displayName: "Bar chart", dataRoleNames: ["Category", "Y", "Tooltips"] },
+    { name: "pieChart", displayName: "Pie chart", dataRoleNames: ["Category", "Y", "Tooltips"] },
+    { name: "lineChart", displayName: "Line chart", dataRoleNames: ["Category", "Series", "Y"] },
 ];
 
 // Define the available fields for each data role
 const dataRolesToFields = [
-    { dataRole: "Axis", Fields: ["Industry", "Opportunity Status", "Lead Rating", "Salesperson"] },
-    { dataRole: "Values", Fields: ["Actual Revenue", "Estimated Revenue", "Number of Opportunities", "Salesperson"] },
-    { dataRole: "Legend", Fields: ["Industry", "Lead Rating", "Opportunity Status", "Salesperson"] },
-    { dataRole: "Tooltips", Fields: ["Industry", "Actual Close Date", "Actual Revenue", "Estimated Revenue"] },
+   { dataRole: "Axis", dataRoleName:"Category", Fields: ["Industry", "Opportunity Status", "Lead Rating", "Salesperson"] },
+    { dataRole: "Values",dataRoleName:"Y", Fields: ["Actual Revenue", "Estimated Revenue", "Number of Opportunities", "Salesperson"] },
+    { dataRole: "Legend",dataRoleName:"Series", Fields: ["Industry", "Lead Rating", "Opportunity Status", "Salesperson"] },
+    { dataRole: "Tooltips",dataRoleName:"Tooltips", Fields: ["Industry", "Actual Close Date", "Actual Revenue", "Estimated Revenue"] },
 ];
 
 // Define schemas for visuals API


### PR DESCRIPTION
In this PR I remove the use of DataRoles tied to the chart type and use the Data Role Names instead, this resolves an error I noticed when the recent update came out in June of 2022. The dataroles the showcase uses were outdated due to the updates made to Power BI. By leveraging the Data Role Names the showcase is able to run and allow users to test out creating their own visuals

Closes #4  